### PR TITLE
Adds support for looping

### DIFF
--- a/lib/keyframes.js
+++ b/lib/keyframes.js
@@ -9,6 +9,7 @@ export default class Keyframes extends React.Component {
     delay: PropTypes.number,
     loop: PropTypes.oneOfType([
       React.PropTypes.string,
+      React.PropTypes.number,
       React.PropTypes.bool
     ]),
     onStart: PropTypes.func,
@@ -18,14 +19,17 @@ export default class Keyframes extends React.Component {
   static defaultProps = {
     component: 'span',
     delay: 0,
-    lopp: false,
+    loop: 1,
     onStart: noop,
     onEnd: noop
   };
 
   constructor (props) {
     super(props);
-    this.state = { frameNum: this.props.delay ? -1 : 0 };
+    this.state = {
+      frameNum: this.props.delay ? -1 : 0,
+      loopNum: 0
+    };
     this.timer = null;
   }
 
@@ -70,9 +74,13 @@ export default class Keyframes extends React.Component {
   requestNextFrame () {
     this.waitForDelay(() => {
       const frameNum = this.state.frameNum + 1;
+      const loopNum = this.state.loopNum + 1;
       if (this.props.children.length <= frameNum) {
-        if (this.props.loop === true || this.props.loop === 'infinite') {
-          this.setState({ frameNum: 0 });
+        if (this.props.loop === true || this.props.loop == 'infinite' || loopNum < this.props.loop) {
+          this.setState({
+            frameNum: 0,
+            loopNum
+          });
         } else {
           this.props.onEnd();
           return;

--- a/lib/keyframes.js
+++ b/lib/keyframes.js
@@ -74,11 +74,12 @@ export default class Keyframes extends React.Component {
   requestNextFrame () {
     this.waitForDelay(() => {
       const frameNum = this.state.frameNum + 1;
+      const loopNum = this.state.loopNum + 1;
       if (this.props.children.length <= frameNum) {
-        if (this.props.loop === true || this.props.loop === 'infinite' || this.state.loopNum < this.props.loop) {
+        if (this.props.loop === true || this.props.loop === 'infinite' || loopNum < this.props.loop) {
           this.setState({
             frameNum: 0,
-            loopNum: this.state.loopNum + 1
+            loopNum
           });
           this.requestNextFrame();
           return;

--- a/lib/keyframes.js
+++ b/lib/keyframes.js
@@ -74,13 +74,14 @@ export default class Keyframes extends React.Component {
   requestNextFrame () {
     this.waitForDelay(() => {
       const frameNum = this.state.frameNum + 1;
-      const loopNum = this.state.loopNum + 1;
       if (this.props.children.length <= frameNum) {
-        if (this.props.loop === true || this.props.loop === 'infinite' || loopNum < this.props.loop) {
+        if (this.props.loop === true || this.props.loop === 'infinite' || this.state.loopNum < this.props.loop) {
           this.setState({
             frameNum: 0,
-            loopNum
+            loopNum: this.state.loopNum + 1
           });
+          this.requestNextFrame();
+          return;
         } else {
           this.props.onEnd();
           return;

--- a/lib/keyframes.js
+++ b/lib/keyframes.js
@@ -7,6 +7,10 @@ export default class Keyframes extends React.Component {
     children: PropTypes.arrayOf(PropTypes.element).isRequired,
     component: PropTypes.any,
     delay: PropTypes.number,
+    loop: PropTypes.oneOfType([
+      React.PropTypes.string,
+      React.PropTypes.bool
+    ]),
     onStart: PropTypes.func,
     onEnd: PropTypes.func
   };
@@ -14,6 +18,7 @@ export default class Keyframes extends React.Component {
   static defaultProps = {
     component: 'span',
     delay: 0,
+    lopp: false,
     onStart: noop,
     onEnd: noop
   };
@@ -66,8 +71,12 @@ export default class Keyframes extends React.Component {
     this.waitForDelay(() => {
       const frameNum = this.state.frameNum + 1;
       if (this.props.children.length <= frameNum) {
-        this.props.onEnd();
-        return;
+        if (this.props.loop === true || this.props.loop === 'infinite') {
+          this.setState({ frameNum: 0 });
+        } else {
+          this.props.onEnd();
+          return;
+        }
       }
 
       this.setState({ frameNum });

--- a/lib/keyframes.js
+++ b/lib/keyframes.js
@@ -76,7 +76,7 @@ export default class Keyframes extends React.Component {
       const frameNum = this.state.frameNum + 1;
       const loopNum = this.state.loopNum + 1;
       if (this.props.children.length <= frameNum) {
-        if (this.props.loop === true || this.props.loop == 'infinite' || loopNum < this.props.loop) {
+        if (this.props.loop === true || this.props.loop === 'infinite' || loopNum < this.props.loop) {
           this.setState({
             frameNum: 0,
             loopNum

--- a/test/index.js
+++ b/test/index.js
@@ -107,3 +107,24 @@ test('Infinite loop', (t) => {
   clock.tick(200);
   t.notOk(onEnd.called);
 });
+
+test('Finite loop', (t) => {
+  const container = document.createElement('div');
+  const onStart = () => onStart.called = true;
+  const onEnd = () => onEnd.called = true;
+  render(
+    <Keyframes onStart={onStart} onEnd={onEnd} loop={3}>
+      <Frame duration={100}>foo</Frame>
+      <Frame duration={100}>bar</Frame>
+    </Keyframes>,
+    container
+  );
+
+  t.ok(onStart.called);
+  clock.tick(100);
+  t.notOk(onEnd.called);
+  clock.tick(200);
+  t.notOk(onEnd.called);
+  clock.tick(300);
+  t.ok(onEnd.called);
+});

--- a/test/index.js
+++ b/test/index.js
@@ -94,7 +94,7 @@ test('Infinite loop', (t) => {
   const onStart = () => onStart.called = true;
   const onEnd = () => onEnd.called = true;
   render(
-    <Keyframes onStart={onStart} onEnd={onEnd} loop={true}>
+    <Keyframes onStart={onStart} onEnd={onEnd} loop>
       <Frame duration={100}>foo</Frame>
       <Frame duration={100}>bar</Frame>
     </Keyframes>,

--- a/test/index.js
+++ b/test/index.js
@@ -88,3 +88,22 @@ test('set component', (t) => {
   t.same(node.tagName, 'PRE');
   t.same(node.className, 'woot');
 });
+
+test('Infinite loop', (t) => {
+  const container = document.createElement('div');
+  const onStart = () => onStart.called = true;
+  const onEnd = () => onEnd.called = true;
+  render(
+    <Keyframes onStart={onStart} onEnd={onEnd} loop={true}>
+      <Frame duration={100}>foo</Frame>
+      <Frame duration={100}>bar</Frame>
+    </Keyframes>,
+    container
+  );
+
+  t.ok(onStart.called);
+  clock.tick(100);
+  t.notOk(onEnd.called);
+  clock.tick(200);
+  t.notOk(onEnd.called);
+});


### PR DESCRIPTION
Hey, thanks so much for open sourcing this. I made terminal animations many different ways while working on Surge.sh, and this is easily one of the most elegant solutions I’ve seen (presumably why you also ended up writing your own!)

While my old approach is still in place there, I actually ended up needing this for something else too, and adding in looping options in the process. To try it out:

```sh
# Install my branch
npm install kennethormandy/react-keyframes#ko-looping
```

```js
import { render } from 'react-dom';
import { Keyframes, Frame } from 'react-keyframes';

render(
  <Keyframes loop> // Just added `loop` to the main example
    <Frame duration={500}>This</Frame>
    <Frame duration={500}>This is</Frame>
    <Frame duration={500}>This is <em>animated</em>.</Frame>
  </Keyframes>,
  document.getElementById('container')
);
```

You can also pass `loop` a number:

```jsx
<Keyframes loop={2}>
  <Frame duration={100}>:)</Frame>
  <Frame duration={100}>;)</Frame>
</Keyframes>
```

If it’s possible to do this with `onEnd` already, I didn’t figure out how that should work. I don’t think my tests are thorough enough, but it’s a start.