### PR TITLE
Adds build as a prepublish script

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
   },
   "scripts": {
     "gulp": "gulp",
-    "test": "ava"
+    "test": "ava",
+    "prepublish": "gulp"
   },
   "babel": {
     "presets": [


### PR DESCRIPTION
Looks like the `build/` directory didn’t get included if you install v0.2.0. Now the default Gulp task will automatically run before `npm publish`.