### PR TITLE
Use `prop-types` package

### DIFF
--- a/lib/frame.js
+++ b/lib/frame.js
@@ -1,4 +1,5 @@
-import React, {PropTypes} from 'react'
+import React from 'react'
+import PropTypes from 'prop-types'
 
 export default class Frame extends React.Component {
   static propTypes = {

--- a/lib/keyframes.js
+++ b/lib/keyframes.js
@@ -1,4 +1,5 @@
-import React, {PropTypes} from 'react'
+import React from 'react'
+import PropTypes from 'prop-types'
 import Frame from './frame'
 
 const noop = () => {}

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "gulp-task-listing": "1.0.1",
     "jsdom": "9.5.0",
     "lolex": "1.5.1",
+    "prop-types": "15.5.10",
     "react": "15.3.2",
     "react-dom": "15.3.1",
     "xo": "^0.17.0"


### PR DESCRIPTION
When utilizing later builds of react using the `react` PropTypes triggers a deprecation warning:

```
Warning: Accessing PropTypes via the main React package is deprecated. Use the prop-types package from npm instead.
```